### PR TITLE
Documentation fixes

### DIFF
--- a/lib/Net/SIP.pod
+++ b/lib/Net/SIP.pod
@@ -32,23 +32,23 @@ in tghe source of L<Net::SIP::Simple>.
 
 =over 4
 
-=item L<SIP::Net::Packet>
+=item L<Net::SIP::Packet>
 
 Is the base class for handling SIP packets and provides ways to
 parse, construct and manipulate SIP packets.
 
-=item L<SIP::Net::Request>
+=item L<Net::SIP::Request>
 
-Is derived from L<SIP::Net::Packet> and handles the request packets.
+Is derived from L<Net::SIP::Packet> and handles the request packets.
 Provides ways to create special requests like ACK or CANCEL based
 on previous requests and responses, for creating responses based
 on requests, for authorization of requests.
 
-=item L<SIP::Net::Response>
+=item L<Net::SIP::Response>
 
-Is derived from L<SIP::Net::Packet> and handles the response packets.
+Is derived from L<Net::SIP::Packet> and handles the response packets.
 
-=item L<SIP::Net::SDP>
+=item L<Net::SIP::SDP>
 
 Handles SDP bodies from SIP packets. Provides ways to parse, construct
 these bodies, to get media information from them and to manipulate the

--- a/lib/Net/SIP/Simple/Call.pod
+++ b/lib/Net/SIP/Simple/Call.pod
@@ -18,7 +18,7 @@ e.g. (re-)invites on existing context etc.
 
 =over 4
 
-=item new ( CONTROL, CTX, \%ARGS )
+=item new ( CONTROL, CTX, %ARGS )
 
 Creates a new L<Net::SIP::Simple::Call> object to control a call.
 Usually called from B<invite> in L<Net::SIP::Simple>.


### PR DESCRIPTION
- In the documentation, `Net::SIP` namespace is incorrectly stated as `SIP::Net`
- `invite` method's third argument has been corrected to hash
