### PR TITLE
do not connect twice after EINPROGRESS

### DIFF
--- a/lib/Net/SIP/SocketPool.pm
+++ b/lib/Net/SIP/SocketPool.pm
@@ -429,7 +429,8 @@ sub _handle_read_tcp_co {
 sub _tcp_connect {
     my Net::SIP::SocketPool $self = shift;
     my ($fo,$peer,$callback,$xxfd) = @_;
-    while (1) {
+    # if called from loop: write handler already set up, already connected
+    while (!$xxfd) {
 	$fo->{didit} = $self->{loop}->looptime;
 	my $rv = connect($fo->{fd},$peer);
 	$DEBUG && DEBUG(100,"tcp connect: ".($rv || $!));
@@ -440,7 +441,6 @@ sub _tcp_connect {
 	}
 	next if $!{EINTR};
 	if ($!{EALREADY} || $!{EINPROGRESS}) {
-	    return if $xxfd; # called from loop: write handler already set up
 	    # insert write handler
 	    $DEBUG && DEBUG(100,"tcp connect: add write handler for async connect");
 	    $self->{loop}->addFD($fo->{fd},1, 


### PR DESCRIPTION
The TCP connect(2) was done twice in case of EINPROGRESS, this
resulted in a fatal EISCONN error.  Only call connect(2) when
_tcp_connect() is run initially.  If it is called after the socket
has become writeable, just finish the job.