### PR TITLE
Fix example in Net::SIP::Debug documentation.

### DIFF
--- a/lib/Net/SIP/Debug.pod
+++ b/lib/Net/SIP/Debug.pod
@@ -5,7 +5,7 @@ Net::SIP::Debug - debugging of Net::SIP
 
 =head1 SYNOPSIS
 
-  use Net::SIP::Debug 1;
+  use Net::SIP::Debug '1';
   use Net::SIP::Debug qw( Net::SIP*=0 Registrar=1 );
   Net::SIP::Debug->level(1);
 


### PR DESCRIPTION
The example "use Net::SIP::Debug 1;" in the documentation does not
work and gives the error "Net::SIP::Debug does not define
$Net::SIP::Debug::VERSION".  Add quotes around '1' in the synopsis.
