### PR TITLE
p5-Net-SIP 0.806 regression test fails and redo seems wrong

### DIFF
--- a/lib/Net/SIP/Dispatcher.pm
+++ b/lib/Net/SIP/Dispatcher.pm
@@ -1010,6 +1010,7 @@ sub __generic_resolver {
 	    if ($i==0) {
 		# remove if top query
 		shift(@$queries);
+		$i--;
 		next;
 	    }
 	    next;

--- a/lib/Net/SIP/Dispatcher.pm
+++ b/lib/Net/SIP/Dispatcher.pm
@@ -1010,7 +1010,7 @@ sub __generic_resolver {
 	    if ($i==0) {
 		# remove if top query
 		shift(@$queries);
-		redo;
+		next;
 	    }
 	    next;
 	}

--- a/lib/Net/SIP/Util.pm
+++ b/lib/Net/SIP/Util.pm
@@ -29,7 +29,7 @@ BEGIN {
     }) {
 	$mod6 = 'IO::Socket::IP';
 	*INETSOCK = sub {
-	    my %args = @_;
+	    my %args = @_ == 1 ? (PeerAddr => $_[0]) : @_;
 	    # Hack to work around the problem that IO::Socket::IP defaults to
 	    # AI_ADDRCONFIG which creates problems if we have only the loopback
 	    # interface. If we already know the family this flag is more harmful


### PR DESCRIPTION
t/05_call_with_stateless_proxy.t ........ 38/378 Odd number of elements in hash assignment at /crypt/home/bluhm/github/p5-net-sip/blib/lib/Net/SIP/Util.pm line 32.
t/05_call_with_stateless_proxy.t ........ 51/378 
#   Failed test '[proxy] (?^:O>.*REQ\(INVITE\) SDP: audio=\S+)'
#   at ./t/testlib.pl line 234.

#   Failed test 'Died at t/05_call_with_stateless_proxy.t line 105.
# '
#   at ./t/testlib.pl line 31.
# Looks like you planned 378 tests but ran 52.
# Looks like you failed 2 tests of 52 run.
# Looks like your test exited with 1 just after 52.
t/05_call_with_stateless_proxy.t ........ Dubious, test returned 1 (wstat 256, 0x100)
Failed 328/378 subtests 