### PR TITLE
Preserve uri parameters on indialog-requests

### DIFF
--- a/lib/Net/SIP/Endpoint/Context.pm
+++ b/lib/Net/SIP/Endpoint/Context.pm
@@ -175,9 +175,9 @@ sub new_request {
 	my ($to,$from) = $self->{incoming} ? ($self->{from},$self->{to})
 	    : ($self->{to},$self->{from});
 	if ( !$uri ) {
-	    ($uri) = sip_hdrval2parts( to => $self->{remote_contact}||$to);
+	    $uri = $self->{remote_contact}||$to;
 	    # XXX handle quotes right, e.g "<bla>" <sip:bla@fasel.com>
-	    $uri = $1 if $uri =~m{<(\S+)>$};
+	    $uri = $1 if $uri =~m{<(\S+)>};
 	}
 
 	# contact is mandatory for INVITE


### PR DESCRIPTION
Some devices (e.g. Snom) send a Contact like this:

sip:user@ip:port;line=abcde

With the current approach splitting the uri to parts, the line
parameter is dropped, and re-INVITE or BYE are rejected by those
devices due to missing line parameters.

The new approach is to take the uri as-is and slightly modify the
uri extraction regex, extracting the full uri including all params
and use that as r-uri.