### PR TITLE
Allow Leg.pm Contact header to be set to a callback or a string

### DIFF
--- a/lib/Net/SIP/Leg.pm
+++ b/lib/Net/SIP/Leg.pm
@@ -657,7 +657,7 @@ sub contact {
     my Net::SIP::Leg $self = shift;
     my $packet = shift;
 
-    my $contact = "temp";
+    my $contact;
     my $cb = 0;
     if (ref $self->{contact} eq 'CODE') {
         $contact = $self->{contact}->($self, $packet);

--- a/lib/Net/SIP/Leg.pm
+++ b/lib/Net/SIP/Leg.pm
@@ -338,7 +338,7 @@ sub forward_outgoing {
 	    my $rr;
 	    unless ( (($rr) = $packet->get_header( 'record-route' ))
 			and sip_uri_eq( $rr, $self->contact($packet))) {
-            $packet->insert_header( 'record-route', $self->contact($packet));
+            $packet->insert_header( 'record-route', '<'.  $self->contact($packet) .';lr>');
         }
 	}
 

--- a/lib/Net/SIP/Leg.pm
+++ b/lib/Net/SIP/Leg.pm
@@ -649,7 +649,7 @@ sub key {
 }
 
 ###########################################################################
-# returns contact header via callback if set
+# returns contact header either directly or via callback if set
 # Args: $self, $packet
 # Returns: contact header value (string)
 ###########################################################################

--- a/lib/Net/SIP/Leg.pm
+++ b/lib/Net/SIP/Leg.pm
@@ -666,7 +666,7 @@ sub contact {
         $contact = $self->{contact};
     }
 
-    DEBUG(90, "Contact header " . ($cb ? "(via cb)" : "" ) . " to use: $contact");
+    DEBUG(90, "Contact header " . ($cb ? "(via cb) " : "" ) . "to use: $contact");
     return $contact;
 }
 

--- a/lib/Net/SIP/Leg.pod
+++ b/lib/Net/SIP/Leg.pod
@@ -76,6 +76,10 @@ to outgoing requests and used within Contact header for 200 Responses to
 INVITE. If not given it will be created based on C<addr>, C<port>
 and C<proto>.
 
+For more flexible use a callback can be provided instead of a string. When
+called this will receive two arguments, the current leg and the current packet
+respectively. If a callback is provided it must return a contact string.
+
 =item tls
 
 Optional arguments to be used in creating a TLS connection, as expected by
@@ -181,5 +185,12 @@ This will return the local address of the socket, either as address only
 
 Returns string containing information about the leg.
 Used for debugging.
+
+=item callback ( PACKET )
+
+Returns the Contact header value based on the supplied B<PACKET>. If the
+current Leg contact attribute is a string this is returned without
+modification. If the contact attribute is instead a callback then this
+is executed with the supplied B<PACKET> and the result returned.
 
 =back

--- a/lib/Net/SIP/StatelessProxy.pm
+++ b/lib/Net/SIP/StatelessProxy.pm
@@ -374,7 +374,7 @@ sub __forward_request_getleg {
     my $route = $route[0] =~m{<([^\s>]+)>} && $1 || $route[0];
     my $ol = $entry->{outgoing_leg};
     if ( $ol && @$ol ) {
-	if ( sip_uri_eq( $route,$ol->[0]{contact})) {
+	if ( sip_uri_eq( $route,$ol->[0]->contact($entry->{packet}))) {
 	    DEBUG(50,"first route header matches choosen leg");
 	    shift(@route);
 	} else {

--- a/t/23_contact_callback.t
+++ b/t/23_contact_callback.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+###########################################################################
+# Create leg that has a contact callback
+# Generate some packets with different 'from' addresses
+# Check the leg->contact method uses the callback
+# Finally, set contact as a string not a CODEREF
+# Check the leg->contact method just returns the string as per old behavior
+###########################################################################
+
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+use Net::SIP ':all';
+
+my $leg = Net::SIP::Leg->new(
+    sock  => \*STDOUT,   # just fake so that it does not create a new socket
+    addr  => '10.0.105.10',
+    port  => '5062',
+    proto => 'udp',
+
+    # Test callback to rewrite the contact address
+    contact => sub {
+        my ($leg, $packet) = @_;
+        if ($packet->get_header('from') =~ m/one\.specific\.domain/) {
+            return 'another.specific.domain';
+        }
+
+        return 'default.domain';
+    }
+);
+
+my $packet = Net::SIP::Packet->new( <<'PKT' );
+NOTIFY sip:john@10.0.100.189:5060 SIP/2.0
+Via: SIP/2.0/UDP 10.0.105.10:5066;branch=z9hG4bK75852cbf.3a07466d.64f68271
+Max-Forwards: 70
+Route: <sip:10.0.105.10:5062;lr>
+Route: <sip:3Zqkv7%0Baqqhyaacc4qsip%3Ajohn%40dgged.dhhd.ahhdgd:7070;maddr=172.25.2.1;lr>
+Contact: <sip:CGP1@10.0.105.10:5066>
+To: <sip:john@10.0.100.189:5060>;tag=nura947nd1hc6sd009bj
+From: <sip:john@one.specific.domain>;tag=13cb22556957d43f-57b1b5d5.0
+Call-ID: HuOAA9-5oIe1iM9neZbyp4fPeoAGdt
+CSeq: 929505408 NOTIFY
+Event: nexos
+Content-Type: application/vnd.ericsson.lmc.sipuaconfig+xml
+P-Asserted-Identity: <sip:john@10.0.100.189:5060>
+Subscription-State: active;expires=3600
+Content-Length: 0
+
+PKT
+
+my $second_packet = Net::SIP::Packet->new( <<'PKT' );
+NOTIFY sip:john@10.0.100.189:5060 SIP/2.0
+Via: SIP/2.0/UDP 10.0.105.10:5066;branch=z9hG4bK75852cbf.3a07466d.64f68271
+Max-Forwards: 70
+Route: <sip:10.0.105.10:5062;lr>
+Route: <sip:3Zqkv7%0Baqqhyaacc4qsip%3Ajohn%40dgged.dhhd.ahhdgd:7070;maddr=172.25.2.1;lr>
+Contact: <sip:CGP1@10.0.105.10:5066>
+To: <sip:john@10.0.100.189:5060>;tag=nura947nd1hc6sd009bj
+From: <sip:john@not.a.specific.domain>;tag=13cb22556957d43f-57b1b5d5.0
+Call-ID: HuOAA9-5oIe1iM9neZbyp4fPeoAGdt
+CSeq: 929505408 NOTIFY
+Event: nexos
+Content-Type: application/vnd.ericsson.lmc.sipuaconfig+xml
+P-Asserted-Identity: <sip:john@10.0.100.189:5060>
+Subscription-State: active;expires=3600
+Content-Length: 0
+
+PKT
+
+is($leg->contact($packet),          "another.specific.domain", "Contact header callback OK");
+is($leg->contact($second_packet),   "default.domain", "Contact header callback returned default");
+
+# Now try the previous approach of setting {contact} as a string
+$leg->{contact} = 'string-contact-as-before.com';
+is($leg->contact($packet),          "string-contact-as-before.com", "Contact supports string with domain 1");
+is($leg->contact($second_packet),   "string-contact-as-before.com", "Contact supports string with domain 2");


### PR DESCRIPTION
This PR primarily updates `Net::SIP::Leg` to allow `$leg->{contact}` to be set to either a string, as per current behavior, or a callback. The callback receives two arguments which are the leg itself plus the current packet that is being processed.

Existing code that relies on being able to reach in and get/set `$leg->{contact}` as a string will continue to work as before. New code that needs advanced contact header functionality can instead set this to a function and hook in to dynamically set the contact header value.

The reasoning for this change is integrating with an external PBX that requires the Contact header must use a subdomain of the domain used in the From header. The same PBX also enforces port 5061. This change allows multiple domains to use a single Leg in this situation, rather than requiring an IP per domain.