### PR TITLE
Handle dst_addr in Endpoint.pm for requests with auth

### DIFF
--- a/lib/Net/SIP/Endpoint.pm
+++ b/lib/Net/SIP/Endpoint.pm
@@ -152,7 +152,7 @@ sub new_request {
     my ($leg,$dst_addr) = delete @args{qw(leg dst_addr)};
 
     if ( ! UNIVERSAL::isa( $ctx,'Net::SIP::Endpoint::Context' )) {
-	$ctx = Net::SIP::Endpoint::Context->new(%$ctx, method => $method);
+	$ctx = Net::SIP::Endpoint::Context->new(%$ctx, method => $method, request_args => { leg => $leg, dst_addr => $dst_addr});
 	$self->{ctx}{ $ctx->callid } = $ctx; # make sure we manage the context
 	DEBUG( 10,"create new request for $method within new call ".$ctx->callid );
     } else {

--- a/lib/Net/SIP/Endpoint/Context.pm
+++ b/lib/Net/SIP/Endpoint/Context.pm
@@ -26,6 +26,7 @@ use fields (
     'via',     # for 'via' header in created responses, comes from incoming request
     'incoming', # flag if call is incoming, e.g. 'to' is myself
     'local_tag', # local tag which gets assigned to either from or to depending on incoming
+    'request_args', # Args to pass into Endpoint::new_request after a 407 when we resubmit with auth
 
     # ===== Internals
     # \@array of hashrefs for infos about pending transactions
@@ -347,7 +348,7 @@ sub handle_response {
 	    # redo request
 	    # update local cseq from cseq in request
 	    ($self->{cseq}) = $r->cseq =~m{(\d+)};
-	    $endpoint->new_request( $r,$self );
+	    $endpoint->new_request( $r,$self, undef, undef, %{$self->{request_args}} );
 	} else {
 	    # need user feedback
 	    DEBUG(10,"no (usable) authorization data available");


### PR DESCRIPTION
Using Net::SIP::Endpoint to register a user with auth we expect to see: REGISTER, 407, REGISTER (AUTH), 200

The dst_addr argument can be passed in to the register function to specify the outbound proxy to use for that request. This works for the initial REGISTER request. However when the 407 response is received and the subsequent REGISTER (AUTH) request is sent the dst_addr argument is not used, resulting in the SIP URI being used instead. This prevents the proper use of the dst_addr argument for requests that require auth.

The same appears to be true of the leg argument, although my use-case does not require this.

This change stores the dst_addr and leg arguments in the context and uses them after a 407 response when the next request is created.