### PR TITLE
Echo back algorithm attribute if set in WWW-Authenticate Response Header

### DIFF
--- a/lib/Net/SIP/Request.pm
+++ b/lib/Net/SIP/Request.pm
@@ -317,6 +317,8 @@ sub authorize {
 		$header.= qq[,cnonce="$digest{cnonce}"] if defined $digest{cnonce};
 		$header.= qq[,qop=$digest{qop}] if defined $digest{qop};
 		$header.= qq[,nc=$digest{nc}] if defined $digest{nc};
+		# Echo back the algorithm if specifically set in response
+		$header.= qq[,algorithm=$h->{algorithm}] if defined $h->{algorithm};
 		$self->add_header( $resp, $header );
 		$auth++;
 	    }


### PR DESCRIPTION
We see some PBXs fail to validate an auth response unless the algorithm attribute provided in the 401 response is also set in the next REGISTER request as well. The attribute is optional and should default to MD5 if not set, however this change would better mimic the far end behavior by explicitly setting the algorithm in the same format to the input attributes from the 401 response.