### PR TITLE
Fix SocketPool to allow short-form content length header

### DIFF
--- a/lib/Net/SIP/SocketPool.pm
+++ b/lib/Net/SIP/SocketPool.pm
@@ -497,7 +497,7 @@ sub _handle_read_tcp_co {
     }
     $hdrpos += 4; # after header
     my %clen = map { $_ => 1 } 
-	substr($fo->{rbuf},0,$hdrpos) =~m{\nContent-length:\s*(\d+)\s*\n}ig;
+	substr($fo->{rbuf},0,$hdrpos) =~m{\n(?:l|Content-length):\s*(\d+)\s*\n}ig;
     if (!%clen) {
 	return $self->_del_socket($fo,
 	    "drop invalid SIP packet from %s: missing content-length",


### PR DESCRIPTION
Whilst Net SIP does normalize headers to handle short-form header keys, `_handle_read_tcp_co` in `SocketPool` has a hard-wired check for the full name `Content-Length` key. This commit adjusts the regex to allow packets that use the short form content length to still be read via this function.