### PR TITLE
Propagate up any SSL connect failures

### DIFF
--- a/lib/Net/SIP/SocketPool.pm
+++ b/lib/Net/SIP/SocketPool.pm
@@ -721,6 +721,7 @@ sub _tls_connect {
 	# permanent error
 	_del_socket($self, $fo,
 	    "SSL connect failed: $SSL_ERROR");
+	invoke_callback($callback,"SSL connect failed: $SSL_ERROR");
     }
 }
 


### PR DESCRIPTION
Without this currently we wait for an application level timeout which means we miss the real reason for the failure.