### PR TITLE
Add support for DTMF via PCMA

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -86,6 +86,7 @@ t/20_channel_on_hold.t
 t/21_channel_on_hold_stateless_proxy.t
 t/22_stateless_proxy_ack_on_error.t
 t/23_valid_message.t
+t/24_dtmf_audio.t
 t/certs/caller.sip.test.pem
 t/certs/listen.sip.test.pem
 t/certs/proxy.sip.test.pem

--- a/t/24_dtmf_audio.t
+++ b/t/24_dtmf_audio.t
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Net::SIP::DTMF qw(dtmf_generator dtmf_extractor);
+
+my $duration = 10;
+my @symbols = split //, '0123456789*#ABCD';
+my %types = (pcmu => 0, pcma => 8);
+
+foreach my $codec (qw(pcmu pcma)) {
+	my @got;
+	my $ext = dtmf_extractor(audio_type => $types{$codec});
+	foreach my $symbol (@symbols, undef) {
+		my $gen = dtmf_generator($symbol, $duration, audio_type => $types{$codec});
+		my $seq = 0;
+		while (my $rtp = $gen->($seq++, $seq*$duration/8000, 0)) {
+			my ($event) = $ext->($rtp);
+			push @got, $event if defined $event;
+		}
+	}
+	is_deeply(\@got, \@symbols, "DTMF audio generator and extractor for codec $codec works");
+}
+
+done_testing();


### PR DESCRIPTION
Some telecommunication operators prefer PCMA codec over PCMU. Analogue
fixed telephone lines support DTMF only via in-band channel so RFC2833
cannot be used.

This patch adds simple support for generating and extracting DTMF via PCMA
codec. PCMU is still preferred and default. DTMF over PCMA would be used
only when user explicitly configure PCMA via rtp_param or when remote peer
is using PCMA (and not PCMU).