### PR TITLE
Fix dispatcher bad check for ip family in srv lookup response

### DIFF
--- a/lib/Net/SIP/Dispatcher.pm
+++ b/lib/Net/SIP/Dispatcher.pm
@@ -1105,7 +1105,7 @@ sub __generic_resolver {
 		$i--;
 	    }
 	    for my $r (@res) {
-		if ($_->{family}) {
+		if ($r->{family}) {
 		    # done: host in SRV record is already IP address
 		    push @$results, $r;
 		    next;


### PR DESCRIPTION
I believe this typo bug only triggers when the DNS has received supplementary records, which is why it doesn't fire in most cases.