### PR TITLE
Fix crash in Net::SIP::Dispatcher when packet with invalid URI is received

### DIFF
--- a/lib/Net/SIP/Dispatcher.pm
+++ b/lib/Net/SIP/Dispatcher.pm
@@ -724,7 +724,11 @@ sub resolve_uri {
 
     my $ip_addr = $param->{maddr};
     {
-	my ($host,$port,$family) = ip_string2parts($domain, $ip_addr ? 1:0);
+	my ($host,$port,$family) = eval { ip_string2parts($domain, $ip_addr ? 1:0) };
+	$host or do {
+	    DEBUG( 50,"bad URI '$uri'" );
+	    return invoke_callback($callback, EHOSTUNREACH );
+	};
 	$default_port = $port if defined $port;
 	if ($family) {
 	    $ip_addr ||= $host;


### PR DESCRIPTION
SIP packet with invalid content 'BYE sip:user@ SIP/2.0' cause Net::SIP::Dispatcher to crash:

    1612049568.3544 DEBUG:<100> Net::SIP::Dispatcher::__deliver[607]: no dst_addr or leg yet, uri='sip:user@'
    invalid hostname 'user@' in 'user@' at /usr/share/perl5/Net/SIP/Util.pm line 541, <$fh> line 1.
            Net::SIP::Util::ip_string2parts("user\@", 0) called at /usr/share/perl5/Net/SIP/Dispatcher.pm line 727
            Net::SIP::Dispatcher::resolve_uri(Net::SIP::Dispatcher=HASH(0x5587241ad5a0), "sip:user\@", ARRAY(0x5587241b6e38), ARRAY(0x5587241b6a48), ARRAY(0x5587241b78b0), undef) called at /usr/share/perl5/Net/SIP/Dispatcher.pm line 624
            Net::SIP::Dispatcher::__deliver(Net::SIP::Dispatcher=HASH(0x5587241ad5a0), Net::SIP::Dispatcher::Packet=HASH(0x5587241b6dc0)) called at /usr/share/perl5/Net/SIP/Dispatcher.pm line 416
            Net::SIP::Dispatcher::deliver(Net::SIP::Dispatcher=HASH(0x5587241ad5a0), Net::SIP::Request=HASH(0x5587241b6b68), "id", "7dcbb40d0d479c8c40c54d878561eeb7 2", "callback", ARRAY(0x5587241b22b8), "leg", undef, ...) called at /usr/share/perl5/Net/SIP/Endpoint.pm line 168
            Net::SIP::Endpoint::new_request(Net::SIP::Endpoint=HASH(0x5587241adfa0), "BYE", Net::SIP::Endpoint::Context=HASH(0x5587241afb80), ARRAY(0x5587241b3120)) called at /usr/share/perl5/Net/SIP/Simple/Call.pm line 384
            Net::SIP::Simple::Call::bye(Net::SIP::Simple::Call=HASH(0x5587241af0f0)) called at /usr/share/perl5/Net/SIP/Simple/RTP.pm line 220
            Net::SIP::Simple::RTP::__ANON__(Net::SIP::Simple::Call=HASH(0x5587241af0f0), HASH(0x5587241afbf8), SCALAR(0x558723abfad8), Net::SIP::Dispatcher::Eventloop::TimerEvent=HASH(0x5587241b3e08)) called at /usr/share/perl5/Net/SIP/Util.pm line 474
            Net::SIP::Util::invoke_callback(ARRAY(0x5587241b3e50), Net::SIP::Dispatcher::Eventloop::TimerEvent=HASH(0x5587241b3e08)) called at /usr/share/perl5/Net/SIP/Dispatcher/Eventloop.pm line 173
            Net::SIP::Dispatcher::Eventloop::loop(Net::SIP::Dispatcher::Eventloop=HASH(0x5587241ad330), undef, SCALAR(0x558723d96768)) called at /usr/share/perl5/Net/SIP/Simple.pm line 268
    1612049568.3572 DEBUG:<100> Net::SIP::Simple::Call::DESTROY[131]: done

This change fixes above issue by calling ip_string2parts() function in eval
to ensure that it does not crash whole Net::SIP module.