### PR TITLE
Fix setting IP address in Contact and Via headers when leg is listening on wildcard address

### DIFF
--- a/lib/Net/SIP/Leg.pod
+++ b/lib/Net/SIP/Leg.pod
@@ -140,9 +140,10 @@ Returns TRUE if the top B<Via> header in the L<Net::SIP::Packet> PACKET contains
 the B<branch>-tag from C<$self>, otherwise FALSE. Used to check if the response
 came in through the same leg the response was send.
 
-=item add_via ( PACKET )
+=item add_via ( PACKET, ADDR )
 
-Adds itself to PACKET as B<Via> header.
+Adds itself to PACKET as B<Via> header. Optional destination ADDR is a hash
+with at least C<addr> key.
 
 =item can_deliver_to ( ADDR|%SPEC )
 

--- a/lib/Net/SIP/StatelessProxy.pm
+++ b/lib/Net/SIP/StatelessProxy.pm
@@ -578,7 +578,7 @@ sub __forward_packet_final {
     }
 
     if ( $outgoing_leg != $incoming_leg and $packet->is_request ) {
-	$incoming_leg->add_via($packet);
+	$incoming_leg->add_via($packet, $dst_addr);
     }
 
     # prepare outgoing packet


### PR DESCRIPTION
In some situation it makes sense to create Net::SIP::Leg to listen on
wildcard IPv4 address 0.0.0.0 or IPv6 ::

But in this case it is needed to fill correct IP address in Contact and Via
headers of outgoing interface.

This change fixes IP address in Contact and Via headers via laddr4dst()
function which retrieves local IP address uses for connecting to
destination address.