### PR TITLE
Fix resolving hostnames with SRV records

### DIFF
--- a/lib/Net/SIP/Dispatcher.pm
+++ b/lib/Net/SIP/Dispatcher.pm
@@ -1063,7 +1063,7 @@ sub __generic_resolver {
     for(my $i=0; $i<@$queries; $i++) {
 	my $q = $queries->[$i];
 	if ($q->{type} eq 'BREAK-IF-RESULTS') {
-	    if (@$results) {
+	    if (@$results and $i==0) {
 		# skip remaining queries
 		@$queries = ();
 		last;


### PR DESCRIPTION
Resolving hostname is done by quering records in following order:
SRV-udp, SRV-tcp, BREAK-IF-RESULTS, A, AAAA

In case SRV-udp record exists with valid A or AAAA hostname then resolver
stops resolving as it sees BREAK-IF-RESULTS.

But in case Net::SIP has only TCP leg, this SRV-udp result is unusable and
because BREAK-IF-RESULTS already happened, Net::SIP does not have any usable
resolved hostname. And returns just error message:

    Net::SIP::Dispatcher::__resolve_uri_final[864]: no leg with udp to ...

Fix this issue by processing BREAK-IF-RESULTS after waiting for result of
all queries which are before BREAK-IF-RESULTS.

Now BREAK-IF-RESULTS does not happen prior resolving SRV-udp (which creates
a new A and AAAA queries) and also prior resolving SRV-tcp (which again
creates a new A and AAAA queries) and required prerequisites.

If BREAK-IF-RESULTS is not the first entry in $results array, it means that
there is still some unprocessed entry prior BREAK-IF-RESULTS, which has to
be processed prior breaking.