### PR TITLE
Do not crash when received malformed SDP packet

### DIFF
--- a/lib/Net/SIP/Packet.pm
+++ b/lib/Net/SIP/Packet.pm
@@ -720,7 +720,7 @@ sub sdp_body {
     my $ct = $self->get_header( 'content-type' );
     return if $ct && lc($ct) ne 'application/sdp';
     my $body = ($self->as_parts)[3] || return;
-    return Net::SIP::SDP->new( $body );
+    return eval { Net::SIP::SDP->new( $body ) };
 }
 
 ###########################################################################


### PR DESCRIPTION
Net::SIP::SDP->new() can die in case supplied body is malformed.
Net::SIP::Packet's sdp_body() method is called for every received SDP
packet with packet content. So put Net::SIP::SDP->new() call into eval
block to prevent Net::SIP crashing.