### PR TITLE
Allow square brackets in Call ID

### DIFF
--- a/lib/Net/SIP/Packet.pm
+++ b/lib/Net/SIP/Packet.pm
@@ -511,7 +511,7 @@ sub as_parts {
 }
 
 {
-    my $word_rx = qr{[\w\-\.!%\*+`'~()<>:"/?{}\x1c\x1b\x1d]+};
+    my $word_rx = qr{[\w\-\.!%\*+`'~()<>:"/?{}\[\]\x1c\x1b\x1d]+};
     my $callid_rx = qr{^$word_rx(?:\@$word_rx)?$};
     my %key2parser = (
 

--- a/t/23_valid_message.t
+++ b/t/23_valid_message.t
@@ -95,6 +95,17 @@ Contact: <sip:bar@example.com>
 
 REQ
 
+check(undef, <<'REQ');
+INVITE sip:foo@bar.com SIP/2.0
+From: <sip:me@example.com>
+To: <sip:you@example.com>
+Call-Id: foobar@example.com[123]
+Cseq: 20 INVITE
+Content-length: 0
+Contact: <sip:foo@example.com>
+
+REQ
+
 done_testing();
 
 sub check {


### PR DESCRIPTION
This is supported in the word definition in RFC3261 [1] but currently fails. This commit extends the regex to include square brackets and also adds a test.

[1] - https://datatracker.ietf.org/doc/html/rfc3261#section-25.1