### PR TITLE
Ensure ACK packets created include a max-forwards header

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -88,6 +88,7 @@ t/22_stateless_proxy_ack_on_error.t
 t/23_valid_message.t
 t/24_dtmf_audio.t
 t/25_register_tcp_timeout.t
+t/26_request_ack.t
 t/certs/caller.sip.test.pem
 t/certs/listen.sip.test.pem
 t/certs/proxy.sip.test.pem

--- a/lib/Net/SIP/Request.pm
+++ b/lib/Net/SIP/Request.pm
@@ -131,13 +131,14 @@ sub create_ack {
 	$auth{$_} = $v;
     }
     my $header = {
-	'call-id' => scalar($self->get_header('call-id')),
-	from      => scalar($self->get_header('from')),
+	'call-id'       => scalar($self->get_header('call-id')),
+	from            => scalar($self->get_header('from')),
 	# unlike CANCEL the 'to' header is from the response
-	to        => [ $response->get_header('to') ],
-	via       => [ ($self->get_header( 'via' ))[0] ],
-	route     => [ $self->get_header( 'route' ) ],
-	cseq      => $cseq,
+	to              => [ $response->get_header('to') ],
+	via             => [ ($self->get_header( 'via' ))[0] ],
+	route           => [ $self->get_header( 'route' ) ],
+	cseq            => $cseq,
+	'max-forwards'  => 70,
 	%auth,
     };
     return Net::SIP::Request->new( 'ACK',$self->uri,$header );

--- a/t/26_request_ack.t
+++ b/t/26_request_ack.t
@@ -1,0 +1,53 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+
+use Net::SIP::Packet;
+use Net::SIP::Request;
+use Net::SIP::Response;
+
+
+#
+# Make a request/response pair
+# check the ack created from pair contains max-forwards
+#
+{
+    my $request = Net::SIP::Packet->new( <<'PKT' );
+INVITE sip:12345@test.com;user=phone SIP/2.0
+Via: SIP/2.0/TLS 1.2.3.4:12724;rport;branch=z9hG4bKPjdb8ba426-b677-4eab-ab93
+From: <sip:from_user_foo@test.com>;tag=6ad927f7-2a88-48bb-b534-d827304ac0ec
+To: "User" <sip:+12345@test.com;user=phone>
+Contact: <sip:from_user_foo@test.domain.com:12724;transport=TLS>
+Call-ID: 2006b768-b9b9-4fc4-87c2-3bc205f0a60b
+CSeq: 8963 INVITE
+Allow: INVITE, ACK, BYE
+Supported: 100rel, timer, replaces, norefersub
+Session-Expires: 1800
+Min-SE: 90
+
+PKT
+
+    my $response = Net::SIP::Packet->new( <<'PKT' );
+SIP/2.0 400 Bad Request
+Via: SIP/2.0/TLS 1.2.3.4:12724;rport;branch=z9hG4bKPjdb8ba426-b677-4eab-ab93
+From: <sip:from_user_foo@test.com>;tag=6ad927f7-2a88-48bb-b534-d827304ac0ec
+To: "User" <sip:+12345@test.com;user=phone>
+Contact: <sip:from_user_foo@test.domain.com:12724;transport=TLS>
+Call-ID: 2006b768-b9b9-4fc4-87c2-3bc205f0a60b
+CSeq: 8963 INVITE
+Min-SE: 90
+
+PKT
+
+    ok($request, "Request created OK");
+    ok($request, "Response created OK");
+
+    my $ack = $request->create_ack($response);
+    ok($ack, "ACK packeted created OK");
+    ok($ack->get_header('max-forwards'), "ACK includes max-forwards");
+}
+
+done_testing();
+


### PR DESCRIPTION
RFC 3261 8.1.1 says all requests need to include a max-forwards header, which is covered already in Net SIP lib except for ACKs which are generated in a different way. This PR resolves that and also includes a test to check ACKs include the header.