### PR TITLE
Catch empty packets separately to clean up logs

### DIFF
--- a/lib/Net/SIP/Packet.pm
+++ b/lib/Net/SIP/Packet.pm
@@ -648,7 +648,9 @@ sub as_parts {
 	my @header = split( m{\r?\n}, $header );
 
 	my $key2check;
-	if ( $header[0] =~m{^SIP/2.0\s+(\d+)\s+(\S.*?)\s*$} ) {
+	if ( !length($header[0]) ) {
+	    die "bad request: empty packet\n";
+	} elsif ( $header[0] =~m{^SIP/2.0\s+(\d+)\s+(\S.*?)\s*$} ) {
 	    # Response, e.g. SIP/2.0 407 Authorization required
 	    $result{code} = $1;
 	    $result{text} = $2;

--- a/t/23_valid_message.t
+++ b/t/23_valid_message.t
@@ -106,6 +106,9 @@ Contact: <sip:foo@example.com>
 
 REQ
 
+# Don't try to parse a headers keepalive packet of null chars
+check(qr/empty packet/, "\r\n\r\n" . (chr(hex('00')) x 12));
+
 done_testing();
 
 sub check {


### PR DESCRIPTION
Some PBXs send keep alive packets which are just null bytes. Net SIP will try and parse the packet and correctly fail, but the request and responses regexes cause warnings to be thrown in the logs.

This change catches empty packets first to allow cleaner logging.