### PR TITLE
Fix choosing RTP sequence number and synchronization source

### DIFF
--- a/lib/Net/SIP/Simple/RTP.pm
+++ b/lib/Net/SIP/Simple/RTP.pm
@@ -334,6 +334,7 @@ sub _receive_rtp {
 sub _send_rtp {
     my ($sock,$loop,$addr,$readfrom,$channel,$targs,$timer) = @_;
 
+    defined $targs->{wseq} or $targs->{wseq} = int( rand( 2**16 ));
     $targs->{wseq}++;
     my $seq = $targs->{wseq};
 
@@ -364,7 +365,6 @@ sub _send_rtp {
     } else {
 	# read from file
 	for(my $tries = 0; $tries<2;$tries++ ) {
-	    $targs->{wseq} ||= int( rand( 2**16 ));
 	    my $fd = $targs->{fd};
 	    if ( !$fd ) {
 		$targs->{repeat} = -1 if $targs->{repeat} < 0;

--- a/t/19_call_with_dtmf.t
+++ b/t/19_call_with_dtmf.t
@@ -159,15 +159,17 @@ sub uas {
     ) || die $!;
 
     # count received RTP data
-    my $received = my $lost = my $lastseq = 0;
+    my $received = my $lost = 0;
+    my $lastseq;
     my $save_rtp = sub {
 	my ($buf,$seq) = @_;
 	#warn substr( $buf,0,10)."\n";
-	my $diff = $seq - $lastseq;
+	defined $lastseq or $lastseq = ($seq-1) % 2**32;
+	my $diff = ($seq - $lastseq) % 2**32;
 	if ($diff == 0) {
 	    diag("duplicate $seq");
 	    next;
-	} elsif ($diff<0) {
+	} elsif ($diff>2**31) {
 	    diag("out of order $seq");
 	    next;
 	}


### PR DESCRIPTION
Ensure that RTP synchronization source id and initial sequence number is unique per RTP stream.