### PR TITLE
Set SocketPool's rbuf and wbuf to empty buffers when adding new peer socket

### DIFF
--- a/lib/Net/SIP/SocketPool.pm
+++ b/lib/Net/SIP/SocketPool.pm
@@ -123,7 +123,7 @@ sub new {
     }
     _add_socket($self,{
 	fd => $fd,
-	$peer ? (peer => $peer) : (),
+	$peer ? (peer => $peer, rbuf => '', wbuf => '') : (),
 	master => 1,
     });
     return $self;


### PR DESCRIPTION
This fixes uninitialized value warnings when new peer socket is initialized
via SocketPool->new method:

Use of uninitialized value in string ne at lib/Net/SIP/SocketPool.pm line 464.
Use of uninitialized value in sysread at lib/Net/SIP/SocketPool.pm line 471.