### PR TITLE
Add Max-Forwards header for ACK and CANCEL requests

### DIFF
--- a/lib/Net/SIP/Request.pm
+++ b/lib/Net/SIP/Request.pm
@@ -138,6 +138,7 @@ sub create_ack {
 	via       => [ ($self->get_header( 'via' ))[0] ],
 	route     => [ $self->get_header( 'route' ) ],
 	cseq      => $cseq,
+	'max-forwards' => 70,
 	%auth,
     };
     return Net::SIP::Request->new( 'ACK',$self->uri,$header );
@@ -167,6 +168,7 @@ sub create_cancel {
 	via       => [ ($self->get_header( 'via' ))[0] ],
 	route     => [ $self->get_header( 'route' ) ],
 	cseq      => $cseq,
+	'max-forwards' => 70,
 	%auth
     };
     return Net::SIP::Request->new( 'CANCEL',$self->uri,$header );


### PR DESCRIPTION
RFC3261 in section 8.1.1.6 Max-Forwards says:

    A UAC MUST insert a Max-Forwards header field into each request it
    originates with a value that SHOULD be 70.

Some SIP clients, like Linphone, mandates that Max-Forwards header is
present in ACK request packet. If not then they reject ACK packet with
400 Bad request packet.

With Linphone this is a big issue as Net::SIP currently is not able to
establish a SIP call because Linphone send 400 Bad request packet on the
final Net::SIP's ACK.

Linphone log of this issue:

    message: 2022-07-30 18:35:06:203 channel [0x55fa6272fdb0]: message sent to [TCP://127.0.0.1:46433], size: [738] bytes
    SIP/2.0 200 Ok
    Via: SIP/2.0/TCP 127.0.0.1:46433;branch=z9hG4bK7d6bcf5224b0dda9b07ed8884f5bfb2a92388c6b48a2df44a4a7313d0fc585
    From: <sip:netsip@localhost>;tag=cbdd6fdcc04873aa299b9a81e11cf2b5
    To: <sip:linphone@localhost>;tag=S0ObCWX
    Call-ID: 2afb7207ebe4a25fcac8eef1e4863747
    CSeq: 1 INVITE
    User-Agent: Linphone/3.12.0 (belle-sip/1.6.3)
    Supported: replaces, outbound
    Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO, UPDATE
    Contact: <sip:linphone@127.0.0.1:5070;transport=tcp>;+sip.instance="<urn:uuid:19606fc5-2f57-4869-ad33-edab268492e9>"
    Content-Type: application/sdp
    Content-Length: 104

    v=0
    o=linphone 1048 825 IN IP4 127.0.0.1
    s=Talk
    c=IN IP4 127.0.0.1
    t=0 0
    m=audio 7078 RTP/AVP 0 8

    message: 2022-07-30 18:35:06:276 channel [0x55fa6272fdb0]: received [341] new bytes from [TCP://127.0.0.1:46433]:
    ACK sip:linphone@127.0.0.1:5070;transport=tcp SIP/2.0
    Via: SIP/2.0/TCP 127.0.0.1:46433;branch=z9hG4bK7d6bcf5224b0dda9b07ed8884f5bfb2a92388c6b48a2df483cbec083ded078
    Call-id: 2afb7207ebe4a25fcac8eef1e4863747
    Cseq: 1 ACK
    From: sip:netsip@localhost;tag=cbdd6fdcc04873aa299b9a81e11cf2b5
    To: <sip:linphone@localhost>;tag=S0ObCWX
    Content-length: 0

    message: 2022-07-30 18:35:06:279 channel [0x55fa6272fdb0] [341] bytes parsed
    error: 2022-07-30 18:35:06:279 Missing mandatory header [Max-Forwards] for message [ACK]
    message: 2022-07-30 18:35:06:279 channel [0x55fa6272fdb0]: message sent to [TCP://127.0.0.1:46433], size: [317] bytes
    SIP/2.0 400 Bad request
    Via: SIP/2.0/TCP 127.0.0.1:46433;branch=z9hG4bK7d6bcf5224b0dda9b07ed8884f5bfb2a92388c6b48a2df483cbec083ded078
    From: <sip:netsip@localhost>;tag=cbdd6fdcc04873aa299b9a81e11cf2b5
    To: <sip:linphone@localhost>;tag=S0ObCWX
    Call-ID: 2afb7207ebe4a25fcac8eef1e4863747
    CSeq: 1 ACK
    Content-Length: 0

So add Max-Forwards header for ACK and CANCEL requests to be compliant with
RFC3261. With this change is also Linphone happy and accepts calls from
Net::SIP without any 400 Bad request error anymore.