### PR TITLE
Fix creating new Net::SIP::Leg with existing peer socket

### DIFF
--- a/lib/Net/SIP/Leg.pm
+++ b/lib/Net/SIP/Leg.pm
@@ -165,9 +165,12 @@ sub new {
 	    $self->{src} = ip_sockaddr2parts($saddr);
 	    $self->{src}{host} = $host if $host;
 	}
-	if (!$dst and my $saddr = getpeername($sock)) {
-	    # set dst from connected socket
-	    $sockpeer = $dst = ip_sockaddr2parts($saddr);
+	if (my $saddr = getpeername($sock)) {
+	    if (!$dst) {
+		# set dst from connected socket
+		$dst = ip_sockaddr2parts($saddr);
+	    }
+	    $sockpeer = $dst;
 	}
     }
 


### PR DESCRIPTION
$sockpeer in Net::SIP::Leg->new method needs to be set always when passed
socket is connected with peer. Fix logic and set $sockpeer also when $dst
was passed to Net::SIP::Leg->new.