### PR TITLE
Fix event loop timers when select() syscall is interrupted

### DIFF
--- a/lib/Net/SIP/Dispatcher/Eventloop.pm
+++ b/lib/Net/SIP/Dispatcher/Eventloop.pm
@@ -200,12 +200,15 @@ sub loop {
 	my $nfound = select($vec[0],$vec[1], undef, $to);
 	$DEBUG && DEBUG(100,"AFTER  read=%s write=%s nfound=%d",
 	    unpack("b*",$vec[0]), unpack("b*",$vec[1]), $nfound);
-	if ($nfound<0) {
-	    next if $! == EINTR;
-	    die $!
-	};
+	my $select_err = $!;
 
 	$looptime = $self->{now} = gettimeofday();
+
+	if ($nfound<0) {
+	    next if $select_err == EINTR;
+	    die $select_err;
+	};
+
 	$self->{just_dropped} = [];
 
 	for(my $i=0; $nfound>0 && $i<@$fds; $i++) {


### PR DESCRIPTION
select() syscall is blocking call during which system time can change a
lot. If eventloop is waiting in the select() syscall for scheduled timer
with big timeout (e.g. 10 minutes) and syscall is interrupted then
eventloop starts executing timers from the time of previous start of
select() syscall. So if scheduled timer has timeout 10 minutes, select() is
interrupted after 5 minutes then timer is called in the best case after 15
minutes.

Fix this issue by updating internal eventloop timestamp also when select()
syscall is interrupted. So next select() syscall is called with updated
timeout value which reflects waiting in the previous select() call.

Fixes https://github.com/noxxi/p5-net-sip/issues/58