### PR TITLE
Fix warnings with Perl 5.42.

### DIFF
--- a/lib/Net/SIP/Simple/Call.pm
+++ b/lib/Net/SIP/Simple/Call.pm
@@ -727,7 +727,7 @@ sub _setup_local_rtp_socks {
 	for my $m (@{$sdpo->{media}}) {
 	    my $paddr = ip_canonical($m->{addr});
 	    goto skip if !$m->{port} or  $paddr eq '0.0.0.0' or  $paddr eq '::'; # on hold
-	    goto skip if !$m->{media} eq 'audio'; # no DMTF transport
+	    goto skip if $m->{media} ne 'audio'; # no DMTF transport
 
 	    my @fmt =
 		! defined $m->{fmt} ? () :

--- a/lib/Net/SIP/StatelessProxy.pm
+++ b/lib/Net/SIP/StatelessProxy.pm
@@ -508,7 +508,7 @@ sub __forward_packet_final {
 
     my $dst_addr = $entry->{dst_addr};
     my $legs = $entry->{outgoing_leg};
-    if ( !@$legs == @$dst_addr ) {
+    if ( @$legs != @$dst_addr ) {
 	# get legs from dst_addr
 	my @all_legs = $self->{dispatcher}->get_legs;
 	@$legs = ();


### PR DESCRIPTION

In Debian we are currently applying the following patch to Net-SIP.
We thought you might be interested in it too.

    Description: Fix warnings with Perl 5.42.
      Possible precedence problem between ! and numeric eq (==) at /usr/share/perl5/Net/SIP/StatelessProxy.pm line 511.
      Possible precedence problem between ! and string eq at /usr/share/perl5/Net/SIP/Simple/Call.pm line 730.
    Origin: vendor
    Bug-Debian: https://bugs.debian.org/1113885
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2025-09-04
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libnet-sip-perl/raw/master/debian/patches/perl-5.42-precedence.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
